### PR TITLE
Hana DBaaS support

### DIFF
--- a/spring-cloud-cloudfoundry-hana-service-connector/src/main/java/com/sap/hana/cloud/hcp/cf/HANAServiceInfoCreator.java
+++ b/spring-cloud-cloudfoundry-hana-service-connector/src/main/java/com/sap/hana/cloud/hcp/cf/HANAServiceInfoCreator.java
@@ -27,6 +27,8 @@ public class HANAServiceInfoCreator extends RelationalServiceInfoCreator<HANASer
 	@Override
 	public HANAServiceInfo createServiceInfo(String id, String url) 
 	{
+		url = url.replace("/null", "");
+		url += "&encrypt=true&validateCertificate=true";
 		return new HANAServiceInfo(id, url);
 	}
 	


### PR DESCRIPTION
Minor correction in jdbc url provided by spring-cloud-cloudfoundry-connector.
1. Remove "/null" from "cloud.services.hana.connection.jdbcurl"
2. Enable certificate validation.

Now hana schema binding in cloud foundry should work properly without additional configuration of datasource.